### PR TITLE
enable passing of scope parameter to authorization url

### DIFF
--- a/lib/omniauth/strategies/stripe_connect.rb
+++ b/lib/omniauth/strategies/stripe_connect.rb
@@ -9,6 +9,8 @@ module OmniAuth
         :site => 'https://connect.stripe.com'
       }
 
+      option :authorize_options, [:scope]
+
       uid { raw_info[:stripe_user_id] }
 
       info do


### PR DESCRIPTION
configuration like the folowing now works:

Rails.application.config.middleware.use OmniAuth::Builder do
  provider :stripe_connect, STRIPE_CLIENT_ID, STRIPE_PRIVATE_KEY, :scope => "read_write"
end
