### PR TITLE
Enable passing of stripe_landing and stripe_user fields in the URL

### DIFF
--- a/lib/omniauth/strategies/stripe_connect.rb
+++ b/lib/omniauth/strategies/stripe_connect.rb
@@ -40,6 +40,16 @@ module OmniAuth
         verifier = request.params['code']
         client.auth_code.get_token(verifier, {:redirect_uri => callback_url}.merge(token_params.to_hash(:symbolize_keys => true)).merge(headers))
       end
+
+      alias :old_request_phase :request_phase
+      def request_phase
+        options[:authorize_params].merge!(
+          :stripe_landing => session["omniauth.params"]["stripe_landing"],
+          :stripe_user => session["omniauth.params"]["stripe_user"]
+        )
+        p options
+        old_request_phase
+      end
     end
   end
 end


### PR DESCRIPTION
This commit lets you pass in the `stripe_user` and `stripe_landing` parameters into the URL so that you can dynamically populate them according to the [Stripe Connect Reference](https://stripe.com/docs/connect/reference)

For example this will populate the sign up form with an email address:

```
http://localhost:3000/auth/stripe_connect?stripe_user[email]=test@test.com
```

Or with a Devise example:

```
<%= link_to "stripe connect", user_omniauth_authorize_path(:stripe_connect, stripe_user: {email: "test@test.com"}) %>
```
