### PR TITLE
Clarify RoR example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you hit `/auth/stripe_connect` with any query params, they will be passed alo
 
 ### Ruby on Rails apps with Devise
 
-After setting up Devise to use OmniAuth, you only need to add the following line of code to handle the OAuth2 part of Stripe Connect.
+After setting up Devise to use OmniAuth, you only need to add the following line of code to handle the OAuth2 part of Stripe Connect. Since this Devise initializer code takes care of OmniAuth, do not use a separate OmniAuth initializer.
 
 ```ruby
 # Put this in config/initializers/devise.rb with the rest of your Devise configuration


### PR DESCRIPTION
Hi! On my first read through the README.md, I thought I needed to include both the config/initializers/omniauth.rb and the config/initializers/devise.rb code blocks. Doing so seems to result in duplicate oauth calls. Stripe allows the first one but denies the second one, saying that the code has already been used and is now revoked. I spent a bunch of time debugging devise's and OmniAuth's callbacks, only to realize that I should only use the devise initializer.

I thought I should include both initializers because the "Ruby on Rails apps with Devise" section currently says

> ...you only need to add the following line of code...

I understood that to mean that I should add the devise initializer on top of the previous example code, which was an OmniAuth initializer. Anyway, the README.md patch I included may save the next developer some time.

_Thanks @isaacsanders for such an awesome gem!_ This is very useful.
