### PR TITLE
Removed the unsupported `redirect_uri` parameter.

### DIFF
--- a/lib/omniauth/strategies/stripe_connect.rb
+++ b/lib/omniauth/strategies/stripe_connect.rb
@@ -33,7 +33,7 @@ module OmniAuth
       end
 
       def request_phase
-        redirect client.auth_code.authorize_url({:redirect_uri => callback_url}.merge(authorize_params.merge(request.params)))
+        redirect client.auth_code.authorize_url(authorize_params.merge(request.params))
       end
 
       def build_access_token
@@ -43,7 +43,7 @@ module OmniAuth
           }
         }
         verifier = request.params['code']
-        client.auth_code.get_token(verifier, {:redirect_uri => callback_url}.merge(token_params.to_hash(:symbolize_keys => true)).merge(headers))
+        client.auth_code.get_token(verifier, token_params.to_hash(:symbolize_keys => true).merge(headers))
       end
     end
   end


### PR DESCRIPTION
I was contacted by Stripe last week and informed that they don't consider the `redirect_uri` parameter as valid when it's sent to the /oauth/authorize connect endpoint.

Currently, they're ignoring this parameter, but do have plans to support it in the future.

However, as of September 30, 2013, they will start returning an error on invalid `redirect_uri` parameters sent to the connect endpoint.

To avoid this issue, this pull request simply stops sending the `redirect_uri` parameter to the connect endpoint.

The `redirect_uri` parameter should be specified in your Stripe dashboard, when configuring your OAuth application.
