### PR TITLE
Do not pass redirect_uri by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ gem 'rake'
 
 # Specify your gem's dependencies in omniauth-stripe-connect.gemspec
 gemspec
+
+group :test do
+  gem 'rspec', '>= 2.14'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,9 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+
+desc 'Default: run specs.'
+task :default => :spec
+
+desc "Run specs"
+RSpec::Core::RakeTask.new

--- a/spec/omniauth/strategies/stripe_connect_spec.rb
+++ b/spec/omniauth/strategies/stripe_connect_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe OmniAuth::Strategies::StripeConnect do
+  let(:fresh_strategy){ Class.new(OmniAuth::Strategies::StripeConnect) }
+
+
+  before(:each) do
+    OmniAuth.config.test_mode = true
+    @old_host = OmniAuth.config.full_host
+  end
+
+  after(:each) do
+    OmniAuth.config.full_host = @old_host
+    OmniAuth.config.test_mode = false
+  end
+
+  describe '#authorize_params' do
+    subject { fresh_strategy }
+
+    it 'should include redirect_uri if full_host is set' do
+      OmniAuth.config.full_host = 'https://foo.com/'
+      instance = subject.new('abc', 'def')
+
+      instance.authorize_params[:redirect_uri].should =~ /\Ahttps:\/\/foo\.com/
+    end
+
+    it 'should include redirect_uri if callback_path is set' do
+      # TODO: It would be nice to grab this from the request URL
+      # instead of setting it on the config
+      OmniAuth.config.full_host = 'https://foo.com/'
+      instance = subject.new('abc', 'def', :callback_path => 'bar/baz')
+
+      instance.authorize_params[:redirect_uri].should == 'https://foo.com/bar/baz'
+    end
+
+    it 'should not include redirect_uri by default' do
+      instance = subject.new('abc', 'def')
+
+      expect(instance.authorize_params[:redirect_uri]).to be_nil
+    end
+  end
+
+  describe '#token_params' do
+    subject { fresh_strategy }
+
+    # NOTE: We call authorize_params first in each of these methods
+    # since the OAuth2 gem uses it to setup some state for testing
+
+    it 'should include redirect_uri if full_host is set' do
+      OmniAuth.config.full_host = 'https://foo.com/'
+      instance = subject.new('abc', 'def')
+
+      instance.authorize_params
+      instance.token_params[:redirect_uri].should =~ /\Ahttps:\/\/foo\.com/
+    end
+
+    it 'should include redirect_uri if callback_path is set' do
+      # TODO: It would be nice to grab this from the request URL
+      # instead of setting it on the config
+      OmniAuth.config.full_host = 'https://foo.com/'
+      instance = subject.new('abc', 'def', :callback_path => 'bar/baz')
+
+      instance.authorize_params
+      instance.token_params[:redirect_uri].should == 'https://foo.com/bar/baz'
+    end
+
+    it 'should not include redirect_uri by default' do
+      instance = subject.new('abc', 'def')
+
+      instance.authorize_params
+      expect(instance.token_params[:redirect_uri]).to be_nil
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'rspec'
+require 'omniauth-stripe-connect'


### PR DESCRIPTION
Stripe requires whitelisting specific redirect_uri values.  If you're only going to use the default anyway, it's better not to pass it to avoid conflicts.  

Currently, Stripe allows any value for redirect_uri but ignores it.  In the future this behavior will be deprecated and passing a redirect_uri parameter that does not exactly match the one in the dashboard will cause an error.

Note this commit introduces rspec testing to match the OmniAuth gems.
