### PR TITLE
Fetch stripe user info to conform to auth hash format

### DIFF
--- a/lib/omniauth/strategies/stripe_connect.rb
+++ b/lib/omniauth/strategies/stripe_connect.rb
@@ -16,6 +16,9 @@ module OmniAuth
 
       info do
         {
+          :name => extra_info[:display_name] || extra_info[:business_name] || extra_info[:email],
+          :email => extra_info[:email],
+          :nickname => extra_info[:display_name],
           :scope => raw_info[:scope],
           :livemode => raw_info[:livemode],
           :stripe_publishable_key => raw_info[:stripe_publishable_key]
@@ -23,9 +26,12 @@ module OmniAuth
       end
 
       extra do
-        {
+        e = {
           :raw_info => raw_info
         }
+        e[:extra_info] = extra_info unless skip_info?
+
+        e
       end
 
       credentials do
@@ -38,6 +44,10 @@ module OmniAuth
 
       def raw_info
         @raw_info ||= deep_symbolize(access_token.params)
+      end
+
+      def extra_info
+        @extra_info ||= deep_symbolize(access_token.get("https://api.stripe.com/v1/account").parsed)
       end
 
       def redirect_params


### PR DESCRIPTION
See https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema

This adds things like email and nickname fields to the info hash. This does require an additional HTTP call, but omniauth's base strategy has a skip_info option to skip this sort of fetch if the developer is trying to really optimize for that.