### PR TITLE
Update Auth Hash README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,16 @@ Here is an example of the Auth Hash you get back from calling `request.env['omni
   "provider"=>"stripe_connect",
   "uid"=>"<STRIPE_USER_ID>",
   "info"=> {
+    "email"=>"email@example.com",
+    "name"=>"Name",
+    "nickname"=>"Nickname",
     "scope"=>"read_write", # or "read_only"
     "livemode"=>false,
     "stripe_publishable_key"=>"<STRIPE_PUBLISHABLE_KEY>",
   },
   "credentials"=> {
     "token"=>"<STRIPE_ACCESS_TOKEN>",
+    "refresh_token"=>"<STRIPE_REFRESH_TOKEN>",
     "expires"=>false
   },
   "extra"=> {
@@ -95,6 +99,25 @@ Here is an example of the Auth Hash you get back from calling `request.env['omni
       "scope"=>"read_only",
       "stripe_publishable_key"=>"<STRIPE_PUBLISHABLE_KEY>",
       "livemode"=>false
+    },
+    "extra_info"=> {
+      "business_logo"=>"https://stripe.com/business_logo.png",
+      "business_name"=>"Business Name",
+      "business_url"=>"example.com",
+      "charges_enabled"=>true,
+      "country"=>"US",
+      "default_currency"=>"eur",
+      "details_submitted"=>true,
+      "display_name"=>"Business Name",
+      "email"=>"email@example.com",
+      "id"=>"<STRIPE_USER_ID>",
+      "managed"=>false,
+      "object"=>"account",
+      "statement_descriptor"=>"EXAMPLE.COM",
+      "support_email"=>"support@example.com",
+      "support_phone"=>"123456789",
+      "timezone"=>"Europe/Berlin",
+      "transfers_enabled"=>true
     }
   }
 }


### PR DESCRIPTION
Updating the auth hash provided in the readme.

Source:

#<OmniAuth::AuthHash
    expires=false 
    refresh_token="<RF_TOKEN>" 
    token="<TOKEN>"
>
extra=#<OmniAuth::AuthHash
    extra_info=#<OmniAuth::AuthHash
        business_logo=nil
        business_name=nil
        business_url="<URL>"
        charges_enabled=true
        country="<COUNTRY>"
        default_currency="eur"
        details_submitted=true
        display_name="<NAME>"
        email="<EMAIL>"
        id="<ID>"
        managed=false
        metadata=#<OmniAuth::AuthHash>
        object="account" 
        statement_descriptor="<DESCRIPTION>" 
        support_email=nil 
        support_phone="+49123456789" 
        timezone="Europe/Berlin" 
        transfers_enabled=true
    > 
    raw_info=#<OmniAuth::AuthHash
        livemode=false 
        scope="read_write" 
        stripe_publishable_key="<KEY>" 
        stripe_user_id="<ID>" 
        token_type="bearer"
    >
>
info=#<OmniAuth::AuthHash::InfoHash 
    email="<EMAIL>" 
    livemode=false 
    name="<NAME>" 
    nickname="<NAME>" 
    scope="read_write" 
    stripe_publishable_key="<KEY>"
> 
provider=:stripe_connect 
uid="<ID>"
>