### PR TITLE
Fix parameter passing via state query string

### DIFF
--- a/lib/omniauth/strategies/stripe_connect.rb
+++ b/lib/omniauth/strategies/stripe_connect.rb
@@ -4,6 +4,7 @@ module OmniAuth
   module Strategies
     class StripeConnect < OmniAuth::Strategies::OAuth2
       option :name, :stripe_connect
+      option :jwt_hmac_secret, nil
 
       option :client_options, {
         :site => 'https://connect.stripe.com'
@@ -58,14 +59,26 @@ module OmniAuth
         end
       end
 
-      # NOTE: We call redirect_params AFTER super in these methods intentionally
-      # the OAuth2 strategy uses the authorize_params and token_params methods
-      # to set up some state for testing that we need in redirect_params
-
+      # Manually create a state param, with JWT.
       def authorize_params
-        params = super
-        params = params.merge(request.params) unless OmniAuth.config.test_mode
+        if !OmniAuth.config.test_mode
+          options.authorize_params[:state] = generate_jwt_state(request.params)
+          # Remove querystring params as only `state` is allowed.
+          request.params.clear
+        end
+        params = options.authorize_params.merge(options_for("authorize"))
+        if OmniAuth.config.test_mode
+          @env ||= {}
+          @env["rack.session"] ||= {}
+        end
+        session["omniauth.state"] = params[:state]
         redirect_params.merge(params)
+      end
+
+      # Do validation callbacks, then manually set 'omniauth.params' with decoded JWT.
+      def callback_phase # rubocop:disable AbcSize, CyclomaticComplexity, MethodLength, PerceivedComplexity
+        super
+        @env['omniauth.params'] = decode_jwt_state(session['omniauth.state'])
       end
 
       def token_params
@@ -82,6 +95,33 @@ module OmniAuth
       def build_access_token
         verifier = request.params['code']
         client.auth_code.get_token(verifier, token_params)
+      end
+
+      # Stripe does not allow query string for callback_url. override base strategy.
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
+      def generate_jwt_state(params, hmac_secret = options[:jwt_hmac_secret])
+        payload = {_state: SecureRandom.hex(24)}
+        payload = params.merge(payload) unless params.nil?
+        # use hmac if it is set.
+        if hmac_secret.nil?
+          jwt = JWT.encode(payload, nil, 'none')
+        else
+          jwt = JWT.encode(payload, hmac_secret, 'HS256')
+        end
+        jwt
+      end
+
+      def decode_jwt_state(jwt, hmac_secret = options[:jwt_hmac_secret])
+        if hmac_secret.nil?
+          payload = JWT.decode(jwt, nil, false)
+        else
+          payload = JWT.decode(jwt, hmac_secret, true)
+        end
+        payload.first.delete("_state")
+        payload.first
       end
     end
   end

--- a/omniauth-stripe-connect.gemspec
+++ b/omniauth-stripe-connect.gemspec
@@ -20,4 +20,5 @@ Read the Stripe Connect docs for more details: https://stripe.com/docs/connect
 
   gem.add_dependency 'omniauth', '~> 1.3'
   gem.add_dependency 'omniauth-oauth2', '~> 1.4'
+  gem.add_dependency 'jwt', '~> 1.0'
 end

--- a/spec/omniauth/strategies/stripe_connect_spec.rb
+++ b/spec/omniauth/strategies/stripe_connect_spec.rb
@@ -70,5 +70,30 @@ describe OmniAuth::Strategies::StripeConnect do
       instance.authorize_params
       expect(instance.token_params[:redirect_uri]).to be_nil
     end
+
+    it 'should generate and decode correct JWTs' do
+      instance = subject.new('abc', 'def')
+      hash = {"foo" => "bar", "biz" => "baz"}
+      jwt = instance.generate_jwt_state(hash)
+      hash_internal = JWT.decode(jwt, nil, false).first
+      expect(hash_internal.has_key?("_state")).to be_true
+      hash_jwt_decoded = instance.decode_jwt_state(jwt)
+      expect(hash_jwt_decoded.has_key?("_state")).to be_false
+      expect(hash_jwt_decoded["foo"]).to eql("bar")
+      expect(hash_jwt_decoded["biz"]).to eql("baz")
+    end
+
+    it 'should generate and decode correct JWTs with HMAC' do
+      secret =  "secret_shh"
+      instance = subject.new('abc', 'def')
+      hash = {"foo" => "bar", "biz" => "baz"}
+      jwt = instance.generate_jwt_state(hash, secret)
+      hash_internal = JWT.decode(jwt, nil, false).first
+      expect(hash_internal.has_key?("_state")).to be_true
+      hash_jwt_decoded = instance.decode_jwt_state(jwt, secret)
+      expect(hash_jwt_decoded.has_key?("_state")).to be_false
+      expect(hash_jwt_decoded["foo"]).to eql("bar")
+      expect(hash_jwt_decoded["biz"]).to eql("baz")
+    end
   end
 end


### PR DESCRIPTION
The only URL parameter allowed is the `state` variable with the Stripe Connect API. This PR addresses this change by encapsulating data as well as the default state (http://www.thread-safe.com/2014/05/the-correct--useof-state-parameter-in.html) within a JWT.