### PR TITLE
Overwrite callback_url so that it doesn't include query params since Stripe doesn't support them

### DIFF
--- a/lib/omniauth/strategies/stripe_connect.rb
+++ b/lib/omniauth/strategies/stripe_connect.rb
@@ -75,6 +75,10 @@ module OmniAuth
         redirect_params.merge(params)
       end
 
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       def request_phase
         redirect client.auth_code.authorize_url(authorize_params)
       end

--- a/spec/omniauth/strategies/stripe_connect_spec.rb
+++ b/spec/omniauth/strategies/stripe_connect_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::StripeConnect do
-  let(:fresh_strategy){ Class.new(OmniAuth::Strategies::StripeConnect) }
+  let(:fresh_strategy) { Class.new(OmniAuth::Strategies::StripeConnect) }
 
 
   before(:each) do
@@ -69,6 +69,17 @@ describe OmniAuth::Strategies::StripeConnect do
 
       instance.authorize_params
       expect(instance.token_params[:redirect_uri]).to be_nil
+    end
+  end
+
+  describe '#callback_url' do
+    subject { fresh_strategy }
+    OmniAuth.config.full_host = 'https://foo.com/'
+
+    it 'returns a url with the host and path' do
+      instance = subject.new('abc', 'def', :callback_path => 'bar/baz')
+      instance.authorize_params
+      expect(instance.callback_url).to eq 'https://foo.com/bar/baz'
     end
   end
 end


### PR DESCRIPTION
- Addresses: https://github.com/isaacsanders/omniauth-stripe-connect/issues/48