### PR TITLE
Fixed tutorial link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Here is an example of the Auth Hash you get back from calling `request.env['omni
 ```
 
 ## Additional Tutorials
-[Stripe Connect in Rails Tutorial](http://www.munocreative.com/nerd-notes/winvoice)
+[Stripe Connect in Rails Tutorial](https://web.archive.org/web/20160313043319/http://www.munocreative.com/nerd-notes/winvoice)
 
 ## Contributing
 


### PR DESCRIPTION
The tutorial is extremely useful to getting this up and running, and the link is now dead.

Here's one that still works and provides an archived version of the page.