### PR TITLE
Suggested capabilities and stripe_express callback url

### DIFF
--- a/lib/omniauth-stripe-connect/version.rb
+++ b/lib/omniauth-stripe-connect/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module StripeConnect
-    VERSION = "2.10.1"
+    VERSION = "2.11.0"
   end
 end

--- a/lib/omniauth/strategies/stripe_connect.rb
+++ b/lib/omniauth/strategies/stripe_connect.rb
@@ -81,7 +81,7 @@ module OmniAuth
         if options[:stripe_express]
           stripe_client.options[:authorize_url] = "/express/oauth/authorize"
         end
-        redirect client.auth_code.authorize_url(authorize_params)
+        redirect stripe_client.auth_code.authorize_url(authorize_params)
       end
 
       def build_access_token

--- a/lib/omniauth/strategies/stripe_connect.rb
+++ b/lib/omniauth/strategies/stripe_connect.rb
@@ -11,6 +11,7 @@ module OmniAuth
 
       option :authorize_options, [:scope, :stripe_landing, :always_prompt]
       option :provider_ignores_state, true
+      option :stripe_express, false
 
       uid { raw_info[:stripe_user_id] }
 
@@ -76,6 +77,10 @@ module OmniAuth
       end
 
       def request_phase
+        stripe_client = client
+        if options[:stripe_express]
+          stripe_client.options[:authorize_url] = "/express/oauth/authorize"
+        end
         redirect client.auth_code.authorize_url(authorize_params)
       end
 

--- a/spec/omniauth/strategies/stripe_connect_spec.rb
+++ b/spec/omniauth/strategies/stripe_connect_spec.rb
@@ -82,4 +82,38 @@ describe OmniAuth::Strategies::StripeConnect do
       expect(instance.callback_url).to eq 'https://foo.com/bar/baz'
     end
   end
+
+  describe '#stripe_express' do
+    subject { fresh_strategy }
+    OmniAuth.config.full_host = 'https://foo.com/'
+
+    it 'returns the stripe express auth path' do
+      instance = subject.new('abc', 'def', stripe_express: true)
+      instance.authorize_params
+
+      expect(instance.request_phase[1]['Location'].include?('/express/oauth/authorize')).to eq true
+    end
+  end
+
+  describe '#suggested_capabilities' do
+    subject { fresh_strategy }
+    OmniAuth.config.full_host = 'https://foo.com/'
+
+    it 'returns a url with suggested capabilities params' do
+      instance = subject.new('abc', 'def', stripe_express: true, suggested_capabilities: ['transfers', 'tax_reporting_us_1099_k'])
+      instance.authorize_params
+
+      puts instance.request_phase[1]['Location']
+
+
+      expect(instance.request_phase[1]['Location'].scan('suggested_capabilities').count).to eq(2)
+    end
+
+    it 'does not add if no capabilities supplied' do
+      instance = subject.new('abc', 'def', stripe_express: true, suggested_capabilities: [])
+      instance.authorize_params
+
+      expect(instance.request_phase[1]['Location'].scan('suggested_capabilities').count).to eq(0)
+    end
+  end
 end

--- a/spec/omniauth/strategies/stripe_connect_spec.rb
+++ b/spec/omniauth/strategies/stripe_connect_spec.rb
@@ -103,9 +103,6 @@ describe OmniAuth::Strategies::StripeConnect do
       instance = subject.new('abc', 'def', stripe_express: true, suggested_capabilities: ['transfers', 'tax_reporting_us_1099_k'])
       instance.authorize_params
 
-      puts instance.request_phase[1]['Location']
-
-
       expect(instance.request_phase[1]['Location'].scan('suggested_capabilities').count).to eq(2)
     end
 


### PR DESCRIPTION
Adds two new features, one is to auth to stripe_express.

Another is to add params to suggest capabilities on org signup shown here https://dashboard.stripe.com/connect-update